### PR TITLE
added support for css files loading

### DIFF
--- a/ir_lib_loader.coffee
+++ b/ir_lib_loader.coffee
@@ -5,6 +5,7 @@ IRLibLoader._libs = IRLibLoader._libs or {}
 IRLibLoader.load = (src, options) ->
   self = @
   opt = options
+  cssRE = /\.css$/i
   unless @_libs[src]
     @_libs[src] =
       src: src
@@ -13,13 +14,16 @@ IRLibLoader.load = (src, options) ->
       options: options
     $.ajax({
       url: src
-      dataType: 'script'
+      dataType: if cssRE.test(src)
+                  'text'
+                else
+                  'script'
       success: (data, textStatus, jqxhr) ->        
         lib = self._libs[src]        
         if jqxhr.status is 200
           lib.ready = true
           lib.readyDeps.changed()
-          options.success() if options and options.success
+          options.success(data) if options and options.success
 
       error: () ->
         options.error(arguments) if options and options.error


### PR DESCRIPTION
After my commit CSS files will be identified with ```regexp```.

Then it will be possible to load external CSS files just like js libs.

CSS files content will be returned as plain text and it will be possible to integrate into your markup by creating ```<style />``` tag and passing success response data as it's content:
```javascript
IRLibLoader.load('https://some.cdn.com/third_party.css', 
    success: function(css) {
        $('<style type="text/css">\n' + css + '</style>').appendTo("head")
     });
```