### PR TITLE
Cache scripts by default

### DIFF
--- a/ir_lib_loader.coffee
+++ b/ir_lib_loader.coffee
@@ -14,6 +14,7 @@ IRLibLoader.load = (src, options) ->
       options: options
     $.ajax({
       url: src
+      cache: true
       dataType: if cssRE.test(src)
                   'text'
                 else


### PR DESCRIPTION
Cache scripts by default! Without this, the loader will always load fresh copies of all scripts (this is default jquery $.ajax behavior), which is bad and really slows down all apps.
