### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ wait-on-lib
 
 Use Iron-Router waitOn to load external javascript libraries
 
-###Load one or more independend libraries
+### Load one or more independend libraries
 IRLibLoader returns a handle similar to a subscriptions handle. It is ready as soon as the external script is loaded.
 
     Router.map( function () {
@@ -14,7 +14,7 @@ IRLibLoader returns a handle similar to a subscriptions handle. It is ready as s
       });
     });
 
-###Load dependend libraries
+### Load dependend libraries
 Here we have one.js and two.js. two.js has to be loaded secondly because it depends on one.js. This is how you can do this:
 
     Router.map(function(){


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
